### PR TITLE
调整 `NumIndicator` 底部间距，始终处于导航栏上方

### DIFF
--- a/mojito/src/main/java/net/mikaelzero/mojito/Mojito.kt
+++ b/mojito/src/main/java/net/mikaelzero/mojito/Mojito.kt
@@ -10,6 +10,7 @@ import net.mikaelzero.mojito.interfaces.IMojitoConfig
 import net.mikaelzero.mojito.interfaces.ImageViewLoadFactory
 import net.mikaelzero.mojito.loader.ImageLoader
 import net.mikaelzero.mojito.tools.DataWrapUtil
+import net.mikaelzero.mojito.tools.scanForActivity
 import net.mikaelzero.mojito.ui.ImageMojitoActivity
 
 
@@ -75,14 +76,5 @@ class Mojito {
             activity?.overridePendingTransition(0, 0)
         }
 
-        private fun scanForActivity(context: Context?): Activity? {
-            if (context == null) return null
-            if (context is Activity) {
-                return context
-            } else if (context is ContextWrapper) {
-                return scanForActivity(context.baseContext)
-            }
-            return null
-        }
     }
 }

--- a/mojito/src/main/java/net/mikaelzero/mojito/impl/NumIndicator.java
+++ b/mojito/src/main/java/net/mikaelzero/mojito/impl/NumIndicator.java
@@ -3,16 +3,21 @@ package net.mikaelzero.mojito.impl;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.animation.ValueAnimator;
+import android.app.Activity;
 import android.graphics.Color;
 import android.view.Gravity;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.viewpager.widget.ViewPager;
 import androidx.viewpager2.widget.ViewPager2;
 
 import net.mikaelzero.mojito.interfaces.IIndicator;
+import net.mikaelzero.mojito.tools.CommonExt;
 import net.mikaelzero.mojito.tools.Utils;
 
 import org.w3c.dom.Text;
@@ -30,11 +35,8 @@ public class NumIndicator implements IIndicator {
 
     @Override
     public void attach(FrameLayout parent) {
-        originBottomMargin = Utils.dip2px(parent.getContext(), 16);
-        currentBottomMargin = originBottomMargin;
         FrameLayout.LayoutParams indexLp = new FrameLayout.LayoutParams(FrameLayout.LayoutParams.WRAP_CONTENT, Utils.dip2px(parent.getContext(), 36));
         indexLp.gravity = Gravity.BOTTOM | Gravity.CENTER_HORIZONTAL;
-        indexLp.bottomMargin = originBottomMargin;
 
         numTv = new TextView(parent.getContext());
         numTv.setGravity(Gravity.CENTER_VERTICAL);
@@ -42,6 +44,21 @@ public class NumIndicator implements IIndicator {
         numTv.setTextColor(Color.WHITE);
         numTv.setTextSize(16);
         parent.addView(numTv);
+
+        Activity activity = CommonExt.scanForActivity(parent.getContext());
+        if (activity != null) {
+            ViewCompat.setOnApplyWindowInsetsListener(activity.getWindow().getDecorView(), (v, insets) -> {
+                originBottomMargin = insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom;
+                currentBottomMargin = originBottomMargin;
+
+                if (numTv != null) {
+                    ViewGroup.MarginLayoutParams currentIndexLp = (ViewGroup.MarginLayoutParams) numTv.getLayoutParams();
+                    currentIndexLp.bottomMargin = originBottomMargin;
+                    numTv.setLayoutParams(currentIndexLp);
+                }
+                return insets;
+            });
+        }
     }
 
     @Override

--- a/mojito/src/main/java/net/mikaelzero/mojito/tools/CommonExt.kt
+++ b/mojito/src/main/java/net/mikaelzero/mojito/tools/CommonExt.kt
@@ -1,6 +1,10 @@
+@file:JvmName("CommonExt")
+
 package net.mikaelzero.mojito.tools
 
+import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.view.View
 
 fun Context?.dp2px(dp: Int): Int {
@@ -46,3 +50,12 @@ fun View?.px2dp(px: Int): Int {
     return (px / scale + 0.5f).toInt()
 }
 
+fun scanForActivity(context: Context?): Activity? {
+    if (context == null) return null
+    if (context is Activity) {
+        return context
+    } else if (context is ContextWrapper) {
+        return scanForActivity(context.baseContext)
+    }
+    return null
+}


### PR DESCRIPTION
|小白条|三大金刚键|
|:--:|:--:|
|![小白条](https://user-images.githubusercontent.com/28282306/146330306-3d90047e-ddcb-4380-9cb5-85c36c234203.png)|![三大金刚键](https://user-images.githubusercontent.com/28282306/146330316-b016dfd6-4ddf-48e2-b996-fd7e5828742c.png)|

- 调整 `NumIndicator` 底部间距，始终处于导航栏上方
- 将 scanForActivity 方法移动到 CommonExt